### PR TITLE
Upgrade all projects to .NET 10

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,17 +6,15 @@ environment:
   DOTNET_NOLOGO: true
 
 install:
-  - pwsh: |
-      $installDir = "$env:USERPROFILE\.dotnet"
-      $installScript = "$env:TEMP\dotnet-install.ps1"
-      Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile $installScript -UseBasicParsing
-      & $installScript -Channel 10.0 -InstallDir $installDir
-      $env:PATH = "$installDir;$env:PATH"
-      [System.Environment]::SetEnvironmentVariable('PATH', $env:PATH, [System.EnvironmentVariableTarget]::Process)
-  - dotnet --version
+  - ps: |
+      $ProgressPreference = 'SilentlyContinue'
+      Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -OutFile "$env:TEMP\dotnet-install.ps1" -UseBasicParsing
+      & "$env:TEMP\dotnet-install.ps1" -Channel 10.0 -InstallDir 'C:\dotnet10'
+      Write-Host "Installed .NET SDK:"
+      & 'C:\dotnet10\dotnet' --version
 
 build_script:
-  - dotnet build src/HollowCards/HollowCards.sln --configuration Release
+  - cmd: C:\dotnet10\dotnet build src/HollowCards/HollowCards.sln --configuration Release
 
 test_script:
-  - dotnet test src/HollowCards/HollowCards.UnitTests --configuration Release --no-build
+  - cmd: C:\dotnet10\dotnet test src/HollowCards/HollowCards.UnitTests --configuration Release --no-build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,22 @@
+image: Visual Studio 2022
+
+environment:
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_NOLOGO: true
+
+install:
+  - pwsh: |
+      $installDir = "$env:USERPROFILE\.dotnet"
+      $installScript = "$env:TEMP\dotnet-install.ps1"
+      Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile $installScript -UseBasicParsing
+      & $installScript -Channel 10.0 -InstallDir $installDir
+      $env:PATH = "$installDir;$env:PATH"
+      [System.Environment]::SetEnvironmentVariable('PATH', $env:PATH, [System.EnvironmentVariableTarget]::Process)
+  - dotnet --version
+
+build_script:
+  - dotnet build src/HollowCards/HollowCards.sln --configuration Release
+
+test_script:
+  - dotnet test src/HollowCards/HollowCards.UnitTests --configuration Release --no-build

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestMinor"
+  }
+}

--- a/src/HollowCards/HollowCards.Console/HollowCards.Console.csproj
+++ b/src/HollowCards/HollowCards.Console/HollowCards.Console.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>7.3</LangVersion>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\HollowCards\HollowCards.csproj" />

--- a/src/HollowCards/HollowCards.Tests/HollowCards.Tests.csproj
+++ b/src/HollowCards/HollowCards.Tests/HollowCards.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 
 </Project>

--- a/src/HollowCards/HollowCards.UnitTests/HollowCards.UnitTests.csproj
+++ b/src/HollowCards/HollowCards.UnitTests/HollowCards.UnitTests.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HollowCards\HollowCards.csproj" />

--- a/src/HollowCards/HollowCards/Classes/Deck.cs
+++ b/src/HollowCards/HollowCards/Classes/Deck.cs
@@ -12,7 +12,6 @@ namespace HollowCards
     public class Deck
     {
         private IList<Card> _cards { get; set; }
-        private RNGCryptoServiceProvider _randomProvider { get; }
 
         public int CurrentIndex { get; private set; } = 0;
         public int CardsInDeck { get; }
@@ -28,7 +27,6 @@ namespace HollowCards
                 throw new ArgumentNullException(nameof(configuration), "The configuration must be supplied to the deck");
             }
 
-            _randomProvider = new RNGCryptoServiceProvider();
             _cards = configuration.ConfigureDeck();
             CardsInDeck = _cards.Count;
         }
@@ -100,17 +98,12 @@ namespace HollowCards
             if (numberCards <= 0)
                 throw new ArgumentOutOfRangeException(nameof(numberCards));
 
-            // Create a byte array to hold the random value.
             byte[] randomNumber = new byte[1];
             do
             {
-                // Fill the array with a random value.
-                _randomProvider.GetBytes(randomNumber);
+                RandomNumberGenerator.Fill(randomNumber);
             }
             while (!IsFairChoice(randomNumber[0], numberCards));
-            // Return the random number mod the number
-            // of cards.  The possible values are zero-
-            // based, so we add one.
             return (byte)((randomNumber[0] % numberCards) + 1);
         }
 

--- a/src/HollowCards/HollowCards/HollowCards.csproj
+++ b/src/HollowCards/HollowCards/HollowCards.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>HollowCards</AssemblyTitle>
@@ -10,8 +10,4 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

- Retarget all four projects (`HollowCards`, `HollowCards.UnitTests`, `HollowCards.Tests`, `HollowCards.Console`) from `net8.0`/`netcoreapp2.1` to `net10.0`
- Replace obsolete `RNGCryptoServiceProvider` with `RandomNumberGenerator.Fill()` (the static API introduced in .NET 6; the old type is removed in .NET 10)
- Update test infrastructure packages: `Microsoft.NET.Test.Sdk` 15.9.0 → 17.12.0, `xunit` 2.4.0 → 2.9.3, `xunit.runner.visualstudio` 2.4.0 → 2.8.2
- Remove unused `Microsoft.CSharp` and `System.Data.DataSetExtensions` package references from the library project (both are built into the .NET runtime and were not referenced in code)
- Remove the `<LangVersion>7.3</LangVersion>` pin from the Console project — .NET 10 defaults to C# 13
- Add `global.json` at the repo root pinning the SDK to `10.0.100` with `latestMinor` roll-forward

## Test plan

- [ ] `dotnet build src/HollowCards/HollowCards.sln` succeeds with no errors or obsolete-API warnings
- [ ] `dotnet test src/HollowCards/HollowCards.UnitTests` — all existing unit tests pass
- [ ] `dotnet run --project src/HollowCards/HollowCards.Console` — stress-test of 10,000 decks completes without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ReGiCZTdMgiWiWyHNc37f

---
_Generated by [Claude Code](https://claude.ai/code/session_018ReGiCZTdMgiWiWyHNc37f)_